### PR TITLE
be-43-fix/permissions: fixed permission middleware

### DIFF
--- a/internal/providers/http/middleware/permissions.go
+++ b/internal/providers/http/middleware/permissions.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/tiptop-co/backend/internal/model"
 	"github.com/tiptop-co/backend/internal/model/authz"
@@ -11,12 +13,12 @@ func RequirePermission(p authz.Permission) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		claims := ctxclaims.GetClaims(c)
 		if claims == nil {
-			_ = c.Error(model.ErrUnauthorized)
+			_ = c.AbortWithError(http.StatusUnauthorized, model.ErrUnauthorized)
 			return
 		}
 
 		if !authz.HasPermission(claims.UserRole, p) {
-			_ = c.Error(model.ErrForbidden)
+			_ = c.AbortWithError(http.StatusForbidden, model.ErrForbidden)
 		}
 
 		c.Next()


### PR DESCRIPTION
Баг: при отсутствии необходимых прав миддварь возвращает ошибку, но при этом все равно разрешает выполнить операцию

Причина: c.Error() + return не прерывают цепочку миддварей. Необходимо вызывать c.Abort()

Исправление: добавить  c.AbortWithError(status, error)