### PR TITLE
be-21-feature/tables: управление столами

### DIFF
--- a/api/proto/schema.proto
+++ b/api/proto/schema.proto
@@ -208,6 +208,10 @@ service AuthService {
 // Guest service
 // ─────────────────────────────────────────────
 
+message TableBootstrapRequest {
+  string qr_token = 1;
+}
+
 message GetMenuRequest {
   string table_id = 1;
 }
@@ -263,6 +267,10 @@ message CreateCallRequest {
 }
 
 service GuestService {
+  rpc TableBootstap(TableBootstrapRequest) returns (Table) {
+    option (google.api.http) = { post: "/api/tables/bootstrap" };
+  }
+
   rpc GetMenu(GetMenuRequest) returns (GetMenuResponse) {
     option (google.api.http) = { get: "/api/tables/{table_id}/menu" };
   }
@@ -301,8 +309,7 @@ service GuestService {
 // ─────────────────────────────────────────────
 
 message GetWaiterTablesResponse {
-  repeated Table              active  = 1;
-  repeated ClosedTableSession history = 2;
+  repeated Table tables = 1;
 }
 
 message GetWaiterTableDetailRequest {
@@ -379,6 +386,10 @@ service WaiterService {
 // Manager service
 // ─────────────────────────────────────────────
 
+message CreateTableRequest {
+  int32 number = 1;
+}
+
 message CreateDishRequest {
   string                     name        = 1;
   string                     description = 2;
@@ -418,7 +429,7 @@ message DeleteWaiterRequest {
 }
 
 message GetManagerTablesResponse {
-  repeated Table data = 1;
+  repeated Table tables = 1;
 }
 
 message DeleteTableRequest {
@@ -471,12 +482,12 @@ service ManagerService {
     option (google.api.http) = { get: "/api/manager/tables" };
   }
 
-  rpc CreateTable(Empty) returns (Table) {
+  rpc CreateTable(CreateTableRequest) returns (Table) {
     option (google.api.http) = { post: "/api/manager/tables" body: "*" };
   }
 
   rpc DeleteTable(DeleteTableRequest) returns (Empty) {
-    option (google.api.http) = { delete: "/api/manager/tables/{id}" };
+    option (google.api.http) = { delete: "/api/manager/tables/{table_id}" };
   }
 
   rpc GetStats(Empty) returns (GetManagerStatsResponse) {

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -17,13 +17,17 @@ import (
 	"github.com/tiptop-co/backend/internal/model/authz"
 	creds_postgres "github.com/tiptop-co/backend/internal/repository/auth/credentials/postgres"
 	refresh_redis "github.com/tiptop-co/backend/internal/repository/auth/refresh-token/redis"
+	table_postgres "github.com/tiptop-co/backend/internal/repository/table/postgres"
 	"github.com/tiptop-co/backend/internal/usecase/auth"
+	"github.com/tiptop-co/backend/internal/usecase/table"
 
-	authHandler "github.com/tiptop-co/backend/internal/handler/auth"
+	auth_handler "github.com/tiptop-co/backend/internal/handler/auth"
+	table_handler "github.com/tiptop-co/backend/internal/handler/table"
 
 	"github.com/tiptop-co/backend/internal/providers/http/cookie"
 	"github.com/tiptop-co/backend/internal/providers/http/middleware"
 	bcrypt_hasher "github.com/tiptop-co/backend/internal/providers/password-hasher/bcrypt-hasher"
+	cryptogen "github.com/tiptop-co/backend/internal/providers/tokens/crypto"
 	jwttokens "github.com/tiptop-co/backend/internal/providers/tokens/jwt"
 )
 
@@ -54,11 +58,13 @@ func main() {
 	// REPOSITORIES
 	credsRepo := creds_postgres.NewRepository(pgxpool)
 	refreshTokenRepo := refresh_redis.NewRefreshTokenRepository(redisClient, &cfg.RefreshToken)
+	tableRepo := table_postgres.NewTableRepository(pgxpool)
 
 	// PROVIDERS
 	hasher := bcrypt_hasher.New(cfg.PasswordHasher.Cost)
 	tokenService := jwttokens.New(cfg.AccessToken, cfg.RefreshToken)
 	cookieSetter := cookie.NewCookieTokensSetter(&cfg.AuthCookie)
+	tokenGenerator := cryptogen.NewGenerator()
 
 	// USECASES
 	authUsecase := auth.NewAuthService(
@@ -67,9 +73,11 @@ func main() {
 		hasher,
 		tokenService,
 	)
+	tableUsecase := table.NewTableService(&cfg.TableService, tableRepo, tokenGenerator)
 
 	// HTTP HANDLERS
-	authHandler := authHandler.NewAuthHandler(authUsecase, cookieSetter)
+	authHandler := auth_handler.NewAuthHandler(authUsecase, cookieSetter)
+	tableHandler := table_handler.NewTableHandler(cfg.TableSessionCookie, tableUsecase)
 
 	// ROUTER
 	r := gin.New()
@@ -80,6 +88,7 @@ func main() {
 		gin.Logger(),
 		// middleware.CORSMiddleware(""),
 		middleware.ParseClaims(authUsecase),
+		middleware.ParseTableSession(tableUsecase),
 		middleware.ErrorHandler(logger),
 	)
 
@@ -102,6 +111,22 @@ func main() {
 			middleware.RequirePermission(authz.PermUpdatePassword),
 			authHandler.UpdatePassword,
 		)
+	}
+	tables := apiV1.Group("tables")
+	{
+		tables.POST("/bootstrap", tableHandler.GetByQR)
+	}
+	waiter := apiV1.Group("/waiter")
+	{
+		waiter.GET("/tables", middleware.RequirePermission(authz.PermGetWaiterTables), tableHandler.GetWaiterTables)
+		waiter.GET("/tables/:table_id", middleware.RequirePermission(authz.PermGetTableByID), tableHandler.GetByID)
+		waiter.POST("/tables/:table_id/close", middleware.RequirePermission(authz.PermFreeTable), tableHandler.FreeTable)
+	}
+	manager := apiV1.Group("/manager")
+	{
+		manager.GET("/tables", middleware.RequirePermission(authz.PermGetVenueTables), tableHandler.GetVenueTables)
+		manager.POST("/tables", middleware.RequirePermission(authz.PermCreateTable), tableHandler.CreateTable)
+		manager.DELETE("/tables/:table_id", middleware.RequirePermission(authz.PermDeleteTable), tableHandler.DeleteTable)
 	}
 
 	// SERVER

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tiptop-co/backend
 go 1.26.1
 
 require (
+	github.com/Masterminds/squirrel v1.5.4
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -35,6 +36,8 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
+github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -66,6 +68,10 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
@@ -95,6 +101,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,10 @@ type Config struct {
 	RefreshToken   RefreshTokenConfig   `yaml:"refresh_token"`
 	PasswordHasher PasswordHasherConfig `yaml:"password_hasher"`
 	AuthCookie     AuthCookieConfig     `yaml:"auth_cookie"`
+
+	// TABLE
+	TableService       TableServiceConfig       `yaml:"table_service"`
+	TableSessionCookie TableSessionCookieConfig `yaml:"table_session_cookie"`
 }
 
 type HTTPConfig struct {

--- a/internal/config/table.go
+++ b/internal/config/table.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"time"
+)
+
+type TableServiceConfig struct {
+	QRTokenSize      int `yaml:"qr_token_size" env:"TABLE_QR_TOKEN_SIZE"`
+	SessionTokenSize int `yaml:"session_token_size" env:"TABLE_SESSION_TOKEN_SIZE"`
+}
+
+type TableSessionCookieConfig struct {
+	Domain   string        `env:"TABLE_SESSION_COOKIE_DOMAIN"`
+	Path     string        `env:"TABLE_SESSION_COOKIE_PATH"`
+	Secure   bool          `env:"TABLE_SESSION_COOKIE_SECURE"`
+	HttpOnly bool          `env:"TABLE_SESSION_COOKIE_HTTP_ONLY"`
+	TTL      time.Duration `env:"TABLE_SESSION_COOKIE_TTL"`
+}

--- a/internal/handler/table/dto.go
+++ b/internal/handler/table/dto.go
@@ -1,0 +1,15 @@
+package table_handler
+
+import "github.com/tiptop-co/backend/internal/model/table"
+
+type createTableRequest struct {
+	Number int `json:"number"`
+}
+
+type tableByQRRequest struct {
+	QRToken string `json:"qr_token"`
+}
+
+type tablesResponse struct {
+	Tables []*table.Table `json:"tables"`
+}

--- a/internal/handler/table/table.go
+++ b/internal/handler/table/table.go
@@ -72,6 +72,7 @@ func (h *TableHandler) GetByQR(c *gin.Context) {
 	}
 
 	t := tables[0]
+	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie(
 		"table_session",
 		t.SessionToken,

--- a/internal/handler/table/table.go
+++ b/internal/handler/table/table.go
@@ -1,0 +1,164 @@
+package table_handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tiptop-co/backend/internal/config"
+	"github.com/tiptop-co/backend/internal/model"
+	"github.com/tiptop-co/backend/internal/model/table"
+	"github.com/tiptop-co/backend/internal/providers/http/ctxclaims"
+	usecase "github.com/tiptop-co/backend/internal/usecase/table"
+	"github.com/tiptop-co/backend/pkg/errwrap"
+)
+
+var (
+	ErrTableIDRequired = errors.New("table_id required")
+	ErrQRRequired      = errors.New("qr_token required")
+)
+
+type TableHandler struct {
+	usecase usecase.TableUsecase
+	cfg     config.TableSessionCookieConfig
+}
+
+func NewTableHandler(cfg config.TableSessionCookieConfig, usecase usecase.TableUsecase) *TableHandler {
+	return &TableHandler{
+		usecase: usecase,
+		cfg:     cfg,
+	}
+}
+
+func (h *TableHandler) CreateTable(c *gin.Context) {
+	var request createTableRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		_ = c.Error(errwrap.Wrap(model.ErrValidation, err))
+		return
+	}
+	if request.Number <= 0 {
+		_ = c.Error(model.ErrValidation)
+		return
+	}
+
+	claims := ctxclaims.GetClaims(c)
+
+	table, err := h.usecase.Create(c.Request.Context(), claims.VenueID, request.Number)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, table)
+}
+
+func (h *TableHandler) GetByQR(c *gin.Context) {
+	var request tableByQRRequest
+	if err := c.ShouldBindJSON(&request); err != nil || request.QRToken == "" {
+		_ = c.Error(errwrap.Wrap(model.ErrValidation, ErrQRRequired))
+		return
+	}
+
+	tables, err := h.usecase.GetByFilters(c.Request.Context(), &table.TableFilters{
+		QRToken: &request.QRToken,
+	})
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	if len(tables) == 0 {
+		_ = c.Error(model.ErrNotFound)
+		return
+	}
+
+	t := tables[0]
+	c.SetCookie(
+		"table_session",
+		t.SessionToken,
+		int(h.cfg.TTL.Seconds()),
+		h.cfg.Path,
+		h.cfg.Domain,
+		h.cfg.Secure,
+		h.cfg.HttpOnly,
+	)
+	c.JSON(http.StatusOK, t)
+}
+
+func (h *TableHandler) GetByID(c *gin.Context) {
+	tableID := c.Param("table_id")
+	if tableID == "" {
+		_ = c.Error(errwrap.Wrap(model.ErrValidation, ErrTableIDRequired))
+		return
+	}
+
+	table, err := h.usecase.GetByID(c.Request.Context(), tableID)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, table)
+}
+
+func (h *TableHandler) GetWaiterTables(c *gin.Context) {
+	claims := ctxclaims.GetClaims(c)
+
+	tables, err := h.usecase.GetByFilters(c.Request.Context(), &table.TableFilters{
+		WaiterID: &claims.UserID,
+	})
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, &tablesResponse{
+		Tables: tables,
+	})
+}
+
+func (h *TableHandler) GetVenueTables(c *gin.Context) {
+	claims := ctxclaims.GetClaims(c)
+
+	tables, err := h.usecase.GetByFilters(c.Request.Context(), &table.TableFilters{
+		VenueID: &claims.VenueID,
+	})
+	if err != nil {
+		_ = c.Error(err)
+	}
+
+	c.JSON(http.StatusOK, &tablesResponse{
+		Tables: tables,
+	})
+}
+
+func (h *TableHandler) FreeTable(c *gin.Context) {
+	tableID := c.Param("table_id")
+	if tableID == "" {
+		_ = c.Error(errwrap.Wrap(model.ErrValidation, ErrTableIDRequired))
+		return
+	}
+
+	err := h.usecase.UpdateStatus(c.Request.Context(), tableID, table.StatusFree)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusOK)
+}
+
+func (h *TableHandler) DeleteTable(c *gin.Context) {
+	tableID := c.Param("table_id")
+	if tableID == "" {
+		_ = c.Error(errwrap.Wrap(model.ErrValidation, ErrTableIDRequired))
+		return
+	}
+
+	err := h.usecase.Delete(c.Request.Context(), tableID)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusOK)
+}

--- a/internal/model/authz/permission.go
+++ b/internal/model/authz/permission.go
@@ -6,7 +6,20 @@ package authz
 type Permission string
 
 const (
+	// User
 	PermUpdatePassword Permission = "password:update"
+
+	// Table
+	PermCreateTable  Permission = "table:create"
+	PermDeleteTable  Permission = "table:delete"
+	PermFreeTable    Permission = "table:free"
+	PermGetTableByID Permission = "table:get"
+
+	// Waiter
+	PermGetWaiterTables Permission = "waiter:get_tables"
+
+	// Venue
+	PermGetVenueTables Permission = "venue:get_tables"
 )
 
 type permissionSet map[Permission]struct{}

--- a/internal/model/authz/policy.go
+++ b/internal/model/authz/policy.go
@@ -6,9 +6,16 @@ var rolePermissions = map[UserRole]permissionSet{
 	},
 	RoleManager: {
 		PermUpdatePassword: {},
+		PermCreateTable:    {},
+		PermDeleteTable:    {},
+		PermGetVenueTables: {},
+		PermGetTableByID:   {},
 	},
 	RoleWaiter: {
-		PermUpdatePassword: {},
+		PermUpdatePassword:  {},
+		PermGetWaiterTables: {},
+		PermFreeTable:       {},
+		PermGetTableByID:    {},
 	},
 }
 

--- a/internal/model/error.go
+++ b/internal/model/error.go
@@ -3,8 +3,9 @@ package model
 import "errors"
 
 var (
-	ErrNotFound     = errors.New("not found")
-	ErrValidation   = errors.New("validation error")
-	ErrUnauthorized = errors.New("unauthorized")
-	ErrForbidden    = errors.New("forbidden")
+	ErrNotFound      = errors.New("not found")
+	ErrValidation    = errors.New("validation error")
+	ErrUnauthorized  = errors.New("unauthorized")
+	ErrForbidden     = errors.New("forbidden")
+	ErrAlreadyExists = errors.New("already exists")
 )

--- a/internal/model/table/table.go
+++ b/internal/model/table/table.go
@@ -1,0 +1,37 @@
+package table
+
+type Status string
+
+const (
+	StatusUnspecified Status = "unspecified"
+	StatusFree        Status = "free"
+	StatusUnpaid      Status = "unpaid"
+	StatusPaid        Status = "paid"
+)
+
+type Table struct {
+	ID      string `json:"id" db:"id"`
+	Number  int    `json:"number" db:"number"` // the table number in a particular venue. This is necessary for the convenience of employees.
+	Status  Status `json:"status" db:"status"`
+	VenueID string `json:"venue_id" db:"venue_id"` // ID of cafe, restaurant, etc.
+	QRToken string `json:"qr_token" db:"qr_token"`
+
+	// The session is necessary in order to avoid the "ghost problem".
+	// Previous visitors, whose tabs are still open, will be able to interfere
+	// with the order of current visitors (for example, to order something).
+	//
+	// After the table is closed, the session_token will be updated,
+	// so that the table cart can only be opened via a QR code.
+	SessionToken string `json:"session_token" db:"session_token"`
+
+	WaiterID *string `json:"waiter_id" db:"waiter_id"`
+	OrderID  *string `json:"order_id" db:"order_id"`
+}
+
+type TableFilters struct {
+	TableID  *string
+	QRToken  *string
+	WaiterID *string
+	VenueID  *string
+	Session  *string
+}

--- a/internal/providers/http/middleware/error.go
+++ b/internal/providers/http/middleware/error.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/tiptop-co/backend/internal/model"
+	"github.com/tiptop-co/backend/internal/model/authz"
+	"github.com/tiptop-co/backend/internal/providers/http/ctxclaims"
 	jwttokens "github.com/tiptop-co/backend/internal/providers/tokens/jwt"
 	"github.com/tiptop-co/backend/internal/usecase/auth"
+	"github.com/tiptop-co/backend/internal/usecase/table"
 )
 
 type ErrorResponse struct {
@@ -25,10 +28,25 @@ func ErrorHandler(logger *slog.Logger) gin.HandlerFunc {
 
 		err := c.Errors.Last().Err
 
+		var (
+			userID   string
+			userRole authz.UserRole
+			venueID  string
+		)
+		claims := ctxclaims.GetClaims(c)
+		if claims != nil {
+			userID = claims.UserID
+			userRole = claims.UserRole
+			venueID = claims.VenueID
+		}
+
 		logger.Error("request failed",
 			"method", c.Request.Method,
 			"path", c.Request.URL.Path,
 			"client_ip", c.ClientIP(),
+			"user_id", userID,
+			"user_role", userRole,
+			"venue_id", venueID,
 			"error", err,
 		)
 
@@ -56,7 +74,17 @@ func mapError(err error) (int, string) {
 		errors.Is(err, jwttokens.ErrInvalidSigningMethod):
 		return http.StatusUnauthorized, "invalid_token"
 
+	// TABLE
+	case errors.Is(err, table.ErrTableIsOccupied):
+		return http.StatusConflict, "table is occupied"
+
+	case errors.Is(err, table.ErrInvalidTableSession):
+		return http.StatusUnauthorized, "invalid table session"
+
 	// COMMON
+	case errors.Is(err, model.ErrAlreadyExists):
+		return http.StatusConflict, "already exists"
+
 	case errors.Is(err, model.ErrNotFound):
 		return http.StatusNotFound, "not_found"
 

--- a/internal/providers/http/middleware/permissions.go
+++ b/internal/providers/http/middleware/permissions.go
@@ -19,6 +19,7 @@ func RequirePermission(p authz.Permission) gin.HandlerFunc {
 
 		if !authz.HasPermission(claims.UserRole, p) {
 			_ = c.AbortWithError(http.StatusForbidden, model.ErrForbidden)
+			return
 		}
 
 		c.Next()

--- a/internal/providers/http/middleware/table-session.go
+++ b/internal/providers/http/middleware/table-session.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tiptop-co/backend/internal/model/auth"
+	"github.com/tiptop-co/backend/internal/model/authz"
+	"github.com/tiptop-co/backend/internal/model/table"
+	"github.com/tiptop-co/backend/internal/providers/http/ctxclaims"
+)
+
+type TableSessionValidator interface {
+	ValidateSessionToken(ctx context.Context, token string) (*table.Table, error)
+}
+
+func ParseTableSession(validator TableSessionValidator) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims := ctxclaims.GetClaims(c)
+		// the user is already logged in as not a guest
+		if claims != nil && claims.UserRole != authz.RoleGuest && claims.UserRole != authz.RoleUnspecified {
+			c.Next()
+			return
+		}
+
+		tableSession, err := c.Cookie("table_session")
+		if err != nil {
+			c.Next()
+			return
+		}
+
+		table, err := validator.ValidateSessionToken(c.Request.Context(), tableSession)
+		if err != nil {
+			c.Next()
+			return
+		}
+
+		c.Set("table", table)
+		c.Set("claims", &auth.Claims{
+			UserRole: authz.RoleGuest,
+			VenueID:  table.VenueID,
+		})
+
+		c.Next()
+	}
+}

--- a/internal/providers/tokens/crypto/generator.go
+++ b/internal/providers/tokens/crypto/generator.go
@@ -1,0 +1,21 @@
+package cryptogen
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+type Generator struct{}
+
+func NewGenerator() *Generator {
+	return &Generator{}
+}
+
+func (g *Generator) GenerateToken(size int) (string, error) {
+	b := make([]byte, size)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(b), nil
+}

--- a/internal/repository/table/postgres/table.go
+++ b/internal/repository/table/postgres/table.go
@@ -1,0 +1,211 @@
+package table_postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/tiptop-co/backend/internal/model"
+	"github.com/tiptop-co/backend/internal/model/table"
+)
+
+var (
+	ErrBuildQuery = errors.New("failed to build query")
+	ErrNoFilters  = errors.New("filters must be in the request")
+)
+
+type TableRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewTableRepository(db *pgxpool.Pool) *TableRepository {
+	return &TableRepository{db: db}
+}
+
+func (r *TableRepository) Create(ctx context.Context, t *table.Table) error {
+	query := `
+		INSERT INTO tables (id, venue_id, number, qr_token, session_token, status, waiter_id, order_id)
+		VALUES (@id, @venue_id, @number, @qr_token, @session_token, @status, @waiter_id, @order_id)
+	`
+
+	args := pgx.NamedArgs{
+		"id":            t.ID,
+		"venue_id":      t.VenueID,
+		"number":        t.Number,
+		"qr_token":      t.QRToken,
+		"session_token": t.SessionToken,
+		"status":        t.Status,
+		"waiter_id":     t.WaiterID,
+		"order_id":      t.OrderID,
+	}
+
+	_, err := r.db.Exec(ctx, query, args)
+	if err != nil {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+			err = fmt.Errorf("%w: %w", model.ErrAlreadyExists, err)
+		}
+		return fmt.Errorf("table repository create: %w", err)
+	}
+
+	return nil
+}
+
+func (r *TableRepository) Update(ctx context.Context, t *table.Table) error {
+	query := `
+		UPDATE tables
+		SET
+			number        = @number,
+			qr_token      = @qr_token,
+			session_token = @session_token,
+			status        = @status,
+			waiter_id     = @waiter_id,
+			order_id 	  = @order_id
+		WHERE id = @id
+	`
+
+	args := pgx.NamedArgs{
+		"id":            t.ID,
+		"number":        t.Number,
+		"qr_token":      t.QRToken,
+		"session_token": t.SessionToken,
+		"status":        t.Status,
+		"waiter_id":     t.WaiterID,
+		"order_id":      t.OrderID,
+	}
+
+	cmdTag, err := r.db.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("table repository update: %w", err)
+	}
+
+	if cmdTag.RowsAffected() == 0 {
+		return model.ErrNotFound
+	}
+
+	return nil
+}
+
+func (r *TableRepository) GetByID(ctx context.Context, id string) (*table.Table, error) {
+	query := `
+		SELECT id, venue_id, number, qr_token, session_token, status, waiter_id, order_id
+		FROM tables
+		WHERE id = $1
+	`
+
+	var t table.Table
+
+	err := r.db.QueryRow(ctx, query, id).Scan(
+		&t.ID,
+		&t.VenueID,
+		&t.Number,
+		&t.QRToken,
+		&t.SessionToken,
+		&t.Status,
+		&t.WaiterID,
+		&t.OrderID,
+	)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, model.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("table repository get by id: %w", err)
+	}
+
+	return &t, nil
+}
+
+func (r *TableRepository) GetByFilters(ctx context.Context, filters *table.TableFilters) ([]*table.Table, error) {
+	if filters == nil {
+		return nil, ErrNoFilters
+	}
+
+	query, args, err := r.buildGetRequest(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("table repository get by filters: %w", err)
+	}
+	defer rows.Close()
+
+	var result []*table.Table
+
+	for rows.Next() {
+		var t table.Table
+
+		if err := rows.Scan(
+			&t.ID,
+			&t.VenueID,
+			&t.Number,
+			&t.QRToken,
+			&t.SessionToken,
+			&t.Status,
+			&t.WaiterID,
+			&t.OrderID,
+		); err != nil {
+			return nil, fmt.Errorf("scan table: %w", err)
+		}
+
+		result = append(result, &t)
+	}
+
+	if rows.Err() != nil {
+		return nil, fmt.Errorf("rows error: %w", rows.Err())
+	}
+
+	return result, nil
+}
+
+func (r *TableRepository) buildGetRequest(filters *table.TableFilters) (string, []interface{}, error) {
+	builder := squirrel.
+		Select("id", "venue_id", "number", "qr_token", "session_token", "status", "waiter_id", "order_id").
+		From("tables").
+		PlaceholderFormat(squirrel.Dollar).
+		OrderBy("number ASC")
+
+	if filters.TableID != nil {
+		builder = builder.Where(squirrel.Eq{"id": *filters.TableID})
+	}
+	if filters.QRToken != nil {
+		builder = builder.Where(squirrel.Eq{"qr_token": *filters.QRToken})
+	}
+	if filters.WaiterID != nil {
+		builder = builder.Where(squirrel.Eq{"waiter_id": *filters.WaiterID})
+	}
+	if filters.VenueID != nil {
+		builder = builder.Where(squirrel.Eq{"venue_id": *filters.VenueID})
+	}
+	if filters.Session != nil {
+		builder = builder.Where(squirrel.Eq{"session_token": *filters.Session})
+	}
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: %w", ErrBuildQuery, err)
+	}
+
+	return query, args, nil
+}
+
+func (r *TableRepository) Delete(ctx context.Context, tableID string) error {
+	query := `DELETE FROM tables WHERE id = $1`
+
+	cmdTag, err := r.db.Exec(ctx, query, tableID)
+	if err != nil {
+		return fmt.Errorf("table repository delete: %w", err)
+	}
+
+	if cmdTag.RowsAffected() == 0 {
+		return model.ErrNotFound
+	}
+
+	return nil
+}

--- a/internal/usecase/table/contract.go
+++ b/internal/usecase/table/contract.go
@@ -1,0 +1,44 @@
+package table
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tiptop-co/backend/internal/model/table"
+)
+
+var (
+	ErrTableIsOccupied     = errors.New("table is occupied")
+	ErrInvalidTableSession = errors.New("invalid table session")
+)
+
+type TableUsecase interface {
+	Create(ctx context.Context, venueID string, tableNumber int) (_ *table.Table, err error)
+
+	GetByID(ctx context.Context, tableID string) (_ *table.Table, err error)
+	GetByFilters(ctx context.Context, filters *table.TableFilters) (_ []*table.Table, err error)
+
+	AssignWaiter(ctx context.Context, tableID string, waiterID string) (err error)
+	UnassignWaiter(ctx context.Context, tableID string) (err error)
+
+	UpdateStatus(ctx context.Context, tableID string, status table.Status) (err error)
+	Update(ctx context.Context, table *table.Table) (err error)
+
+	Delete(ctx context.Context, tableID string) (err error)
+
+	ValidateSessionToken(ctx context.Context, sessionToken string) (_ *table.Table, err error)
+}
+
+type TableRepository interface {
+	Create(ctx context.Context, table *table.Table) error
+
+	GetByID(ctx context.Context, tableID string) (*table.Table, error)
+	GetByFilters(ctx context.Context, filters *table.TableFilters) ([]*table.Table, error)
+	Update(ctx context.Context, table *table.Table) error
+
+	Delete(ctx context.Context, id string) error
+}
+
+type TokenGenerator interface {
+	GenerateToken(size int) (string, error)
+}

--- a/internal/usecase/table/table.go
+++ b/internal/usecase/table/table.go
@@ -130,6 +130,7 @@ func (s *TableService) UpdateStatus(ctx context.Context, tableID string, status 
 
 		t.SessionToken = newSessionToken
 		t.WaiterID = nil
+		t.OrderID = nil
 	}
 
 	if err = s.repo.Update(ctx, t); err != nil {
@@ -149,7 +150,7 @@ func (s *TableService) Delete(ctx context.Context, tableID string) (err error) {
 		return fmt.Errorf("failed to get table: %w", err)
 	}
 
-	if t.Status == table.StatusPaid || t.Status == table.StatusUnpaid {
+	if t.Status == table.StatusPaid || t.Status == table.StatusUnpaid || t.OrderID != nil {
 		return ErrTableIsOccupied
 	}
 

--- a/internal/usecase/table/table.go
+++ b/internal/usecase/table/table.go
@@ -1,0 +1,196 @@
+package table
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/tiptop-co/backend/internal/config"
+	"github.com/tiptop-co/backend/internal/model"
+	"github.com/tiptop-co/backend/internal/model/table"
+	"github.com/tiptop-co/backend/pkg/errwrap"
+)
+
+type TableService struct {
+	sizeQRToken      int
+	sizeSessionToken int
+
+	repo TableRepository
+	gen  TokenGenerator
+}
+
+func NewTableService(cfg *config.TableServiceConfig,
+	repo TableRepository, gen TokenGenerator) *TableService {
+	return &TableService{
+		sizeQRToken:      cfg.QRTokenSize,
+		sizeSessionToken: cfg.SessionTokenSize,
+
+		repo: repo,
+		gen:  gen,
+	}
+}
+
+func (s *TableService) Create(ctx context.Context, venueID string, tableNumber int) (_ *table.Table, err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] create", err)
+	}()
+
+	if venueID == "" || tableNumber < 0 {
+		return nil, model.ErrValidation
+	}
+
+	qrToken, err := s.gen.GenerateToken(s.sizeQRToken)
+	if err != nil {
+		return nil, fmt.Errorf("generate qr token: %w", err)
+	}
+
+	sessionToken, err := s.gen.GenerateToken(s.sizeSessionToken)
+	if err != nil {
+		return nil, fmt.Errorf("generate session token: %w", err)
+	}
+
+	table := &table.Table{
+		ID:           uuid.New().String(),
+		VenueID:      venueID,
+		Number:       tableNumber,
+		QRToken:      qrToken,
+		SessionToken: sessionToken,
+		Status:       table.StatusFree,
+	}
+
+	if err = s.repo.Create(ctx, table); err != nil {
+		return nil, fmt.Errorf("failed to create: %w", err)
+	}
+
+	return table, nil
+}
+
+func (s *TableService) GetByID(ctx context.Context, tableID string) (_ *table.Table, err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] get by id", err)
+	}()
+
+	return s.repo.GetByID(ctx, tableID)
+}
+
+func (s *TableService) GetByFilters(ctx context.Context, filters *table.TableFilters) (_ []*table.Table, err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] get by filters", err)
+	}()
+
+	return s.repo.GetByFilters(ctx, filters)
+}
+
+func (s *TableService) AssignWaiter(ctx context.Context, tableID string, waiterID string) (err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] assignWaiter", err)
+	}()
+
+	return s.updateWaiter(ctx, tableID, &waiterID)
+}
+
+func (s *TableService) UnassignWaiter(ctx context.Context, tableID string) (err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] unassignWaiter", err)
+	}()
+
+	return s.updateWaiter(ctx, tableID, nil)
+}
+
+func (s *TableService) updateWaiter(ctx context.Context, tableID string, waiterID *string) error {
+	t, err := s.repo.GetByID(ctx, tableID)
+	if err != nil {
+		return fmt.Errorf("failed to get table: %w", err)
+	}
+	t.WaiterID = waiterID
+
+	if err = s.repo.Update(ctx, t); err != nil {
+		return fmt.Errorf("failed to update table's waiter: %w", err)
+	}
+
+	return nil
+}
+
+func (s *TableService) UpdateStatus(ctx context.Context, tableID string, status table.Status) (err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] update status", err)
+	}()
+
+	t, err := s.repo.GetByID(ctx, tableID)
+	if err != nil {
+		return fmt.Errorf("failed to get table: %w", err)
+	}
+
+	t.Status = status
+	if status == table.StatusFree {
+		newSessionToken, err := s.gen.GenerateToken(s.sizeSessionToken)
+		if err != nil {
+			return fmt.Errorf("failed to generate token: %w", err)
+		}
+
+		t.SessionToken = newSessionToken
+		t.WaiterID = nil
+	}
+
+	if err = s.repo.Update(ctx, t); err != nil {
+		return fmt.Errorf("failed to update table info: %w", err)
+	}
+
+	return nil
+}
+
+func (s *TableService) Delete(ctx context.Context, tableID string) (err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] delete", err)
+	}()
+
+	t, err := s.repo.GetByID(ctx, tableID)
+	if err != nil {
+		return fmt.Errorf("failed to get table: %w", err)
+	}
+
+	if t.Status == table.StatusPaid || t.Status == table.StatusUnpaid {
+		return ErrTableIsOccupied
+	}
+
+	if err = s.repo.Delete(ctx, tableID); err != nil {
+		return fmt.Errorf("failed: %w", err)
+	}
+
+	return nil
+}
+
+func (s *TableService) ValidateSessionToken(ctx context.Context, sessionToken string) (_ *table.Table, err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] validate session token", err)
+	}()
+
+	if sessionToken == "" {
+		return nil, model.ErrValidation
+	}
+
+	tables, err := s.repo.GetByFilters(ctx, &table.TableFilters{
+		Session: &sessionToken,
+	})
+	if err != nil {
+		return nil, errwrap.WrapMsg("failed to get table", err)
+	}
+	if len(tables) == 0 {
+		return nil, ErrInvalidTableSession
+	}
+
+	t := tables[0]
+	if t.SessionToken != sessionToken {
+		return nil, ErrInvalidTableSession
+	}
+
+	return t, nil
+}
+
+func (s *TableService) Update(ctx context.Context, table *table.Table) (err error) {
+	defer func() {
+		err = errwrap.WrapMsg("[TABLE USECASE] update", err)
+	}()
+
+	return s.repo.Update(ctx, table)
+}


### PR DESCRIPTION
1. Добавлены базовые ручки для управления столами (get, create, delete, close)
2. Реализованы методы на уровне юзкейса, необходимые в других сервисах (при создании заказа и тд)
3. Добавлена bootstrap-ручка, обрабатывающая переход по QR. Логика работы:
               a. Пользователь переходит по QR (http://tiptop.com/tables/qr_token=123u4h12uhasuhf134sdf)
               b. Фронт отправляет запрос на бэк POST http://tiptop.com/api/v1 с телом {qr_token="123u4h12uhasuhf134sdf"}
               c. Бек находит стол с таким qr_token, выставляет table_session в куках и возвращает информацию о столе, которая может быть использована на фронте
               d. Фронт получает ответ и редиректит на http://tiptop.com/menu
5. Добавлен middleware для проверки table_session: если пользователь еще не авторизован как менеджер, админ или официант, то проверяется наличие table_session токена, если он валидный, то выставляются Claims, которые далее могут использоваться для проверки прав:
```go
c.Set("claims", &auth.Claims{
     UserRole: authz.Guest,
     VenueID: table.VenueID,
 }
```